### PR TITLE
Update requirements for the jupyter notebook

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ tqdm
 scikit-learn
 scikit-image
 pandas
+ipykernel
+matplotlib


### PR DESCRIPTION
The jupyter notebook needs ipykernel and matplotlib to properly execute. They are currently missing.